### PR TITLE
Fixes Tier 3 Lock Upgrade

### DIFF
--- a/code/modules/antagonists/heretic/knowledge/lock_lore.dm
+++ b/code/modules/antagonists/heretic/knowledge/lock_lore.dm
@@ -106,6 +106,10 @@
 	SEND_SOUND(source, 'sound/effects/magic/hereticknock.ogg')
 
 	if(HAS_TRAIT(source, TRAIT_LOCK_GRASP_UPGRADED))
+		var/datum/action/cooldown/spell/touch/mansus_grasp/grasp = locate() in source.actions
+		if(grasp)
+			grasp.next_use_time -= round(grasp.cooldown_time*0.75)
+			grasp.build_all_button_icons()
 		return SECONDARY_ATTACK_CANCEL_ATTACK_CHAIN
 
 	return COMPONENT_USE_HAND


### PR DESCRIPTION

## About The Pull Request

Fixes the grasp cooldown reset on using the grasp on airlocks.

## Changelog
:cl:
fix: fixed lock heretic's T3 upgrade not working
/:cl: